### PR TITLE
Updated Dockerfile to include git and changed XISF library install method to use GitHub repository.

### DIFF
--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-alpine
 
 # Install system dependencies required to compile Python packages
-RUN apk add --no-cache build-base
+RUN apk add --no-cache build-base git
 
 WORKDIR /opt/scripts
 
@@ -14,9 +14,8 @@ COPY docker/python/requirements.txt .
 # Install Python packages into the virtual environment
 RUN /opt/venv/bin/pip install --no-cache-dir -r requirements.txt
 
-# Copy and install the local XISF library
-COPY external/xisf /opt/scripts/external/xisf
-RUN /opt/venv/bin/pip install /opt/scripts/external/xisf
+# Copy and install the XISF library
+RUN /opt/venv/bin/pip install git+https://github.com/sergio-dr/xisf.git
 
 # Copy the application scripts
 COPY docker/python/reindex.py .


### PR DESCRIPTION
Fix: Install XISF library from GitHub instead of local directory

**Problem**
The build was failing because the Dockerfile attempted to install the XISF library from a local external/xisf directory that lacked the required setup.py or pyproject.toml file for pip installation.

```shell
 => => naming to docker.io/library/astro-web-indexer-mariadb                                                                                                                                            0.0s
 => [mariadb] resolving provenance for metadata file                                                                                                                                                    0.0s
 => [php  3/10] RUN docker-php-ext-install pdo_mysql zip                                                                                                                                               14.8s
 => [python  5/10] COPY docker/python/requirements.txt .                                                                                                                                                0.0s
 => [python  6/10] RUN /opt/venv/bin/pip install --no-cache-dir -r requirements.txt                                                                                                                    16.0s
 => [php  4/10] RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer                                                                                0.9s
 => [php  5/10] WORKDIR /var/www/html                                                                                                                                                                   0.0s
 => [php  6/10] COPY src/ .                                                                                                                                                                             0.0s
 => [php  7/10] RUN echo v1.0.2-1-g4f37537-dirty > VERSION                                                                                                                                              0.2s
 => [php  8/10] RUN composer install --no-interaction --no-progress --no-dev --optimize-autoloader                                                                                                      0.9s
 => [python  7/10] COPY external/xisf /opt/scripts/external/xisf                                                                                                                                        0.1s
 => ERROR [python  8/10] RUN /opt/venv/bin/pip install /opt/scripts/external/xisf                                                                                                                       0.7s
 => [php  9/10] COPY docker/php/docker-entrypoint.sh /usr/local/bin/                                                                                                                                    0.0s
 => [php 10/10] RUN chmod +x /usr/local/bin/docker-entrypoint.sh                                                                                                                                        0.3s
------
 > [python  8/10] RUN /opt/venv/bin/pip install /opt/scripts/external/xisf:
0.628 ERROR: Directory '/opt/scripts/external/xisf' is not installable. Neither 'setup.py' nor 'pyproject.toml' found.
0.636
0.636 [notice] A new release of pip is available: 23.0.1 -> 25.2
0.636 [notice] To update, run: python -m pip install --upgrade pip
------
Dockerfile:19

--------------------

  17 |     # Copy and install the local XISF library

  18 |     COPY external/xisf /opt/scripts/external/xisf

  19 | >>> RUN /opt/venv/bin/pip install /opt/scripts/external/xisf

  20 |

  21 |     # Copy the application scripts

--------------------

target python: failed to solve: process "/bin/sh -c /opt/venv/bin/pip install /opt/scripts/external/xisf" did not complete successfully: exit code: 1
```

**Solution**
Added Git to Alpine dependencies: Updated the apk add command in the Python Dockerfile to include git package
Install XISF from source: Changed installation method to pull XISF directly from the official GitHub repository

After implementing XISF install method:
```shell
 => => reading from stdin 2.25kB                                                                                                                                                                        0.0s
 => [nginx internal] load build definition from Dockerfile                                                                                                                                              0.0s
 => => transferring dockerfile: 252B                                                                                                                                                                    0.0s
 => [php internal] load build definition from Dockerfile                                                                                                                                                0.0s
 => => transferring dockerfile: 938B                                                                                                                                                                    0.0s
 => [python internal] load build definition from Dockerfile                                                                                                                                             0.0s
 => => transferring dockerfile: 969B                                                                                                                                                                    0.0s
 => [mariadb internal] load build definition from Dockerfile                                                                                                                                            0.0s
 => => transferring dockerfile: 247B                                                                                                                                                                    0.0s
 => [nginx internal] load metadata for docker.io/library/nginx:1.27                                                                                                                                     0.1s
 => [mariadb internal] load metadata for docker.io/library/mariadb:10.11                                                                                                                                0.1s
 => [python internal] load metadata for docker.io/library/python:3.9-alpine                                                                                                                             0.2s
 => [php internal] load metadata for docker.io/library/php:8.3-fpm                                                                                                                                      0.2s
 => [mariadb internal] load .dockerignore                                                                                                                                                               0.0s
 => => transferring context: 2B                                                                                                                                                                         0.0s
 => [python internal] load .dockerignore                                                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                                                         0.0s
 => [mariadb 1/4] FROM docker.io/library/mariadb:10.11@sha256:dbe56e20372fc6d6b8e0e396866ba89c4c7f128c38c4f59aaa54d957db95790c                                                                          0.0s
 => [mariadb internal] load build context                                                                                                                                                               0.0s
 => => transferring context: 93B                                                                                                                                                                        0.0s
 => [nginx 1/4] FROM docker.io/library/nginx:1.27@sha256:6784fb0834aa7dbbe12e3d7471e69c290df3e6ba810dc38b34ae33d3c1c05f7d                                                                               0.0s
 => [nginx internal] load build context                                                                                                                                                                 0.0s
 => => transferring context: 2.12kB                                                                                                                                                                     0.0s
 => CACHED [mariadb 2/4] COPY init.sql /docker-entrypoint-initdb.d/                                                                                                                                     0.0s
 => CACHED [mariadb 3/4] COPY conf.d/custom.cnf /etc/mysql/conf.d/                                                                                                                                      0.0s
 => CACHED [mariadb 4/4] RUN chown -R mysql:mysql /docker-entrypoint-initdb.d/ /etc/mysql/conf.d/                                                                                                       0.0s
 => [mariadb] exporting to image                                                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                                                                 0.0s
 => => writing image sha256:ebf8c56ccc36d788328b6588e91c812586269a45097bd54afb59a131a4ba6fbb                                                                                                            0.0s
 => => naming to docker.io/library/astro-web-indexer-mariadb                                                                                                                                            0.0s
 => [php  1/10] FROM docker.io/library/php:8.3-fpm@sha256:a4ecebb18d6bfff3f67b0b7877f6f8a467be492eb8978e3b45b90be084a0baf4                                                                              0.0s
 => [php internal] load build context                                                                                                                                                                   0.0s
 => => transferring context: 107.78kB                                                                                                                                                                   0.0s
 => CACHED [python 1/9] FROM docker.io/library/python:3.9-alpine@sha256:372f3cfc1738ed91b64c7d36a7a02d5c3468ec1f60c906872c3fd346dda8cbbb                                                                0.0s
 => [python internal] load build context                                                                                                                                                                0.0s
 => => transferring context: 26.80kB                                                                                                                                                                    0.0s
 => [python 2/9] RUN apk add --no-cache build-base git                                                                                                                                                  5.5s
 => CACHED [nginx 2/4] COPY ./docker/nginx/default.conf /etc/nginx/conf.d/default.conf                                                                                                                  0.0s
 => CACHED [nginx 3/4] WORKDIR /var/www/html                                                                                                                                                            0.0s
 => CACHED [nginx 4/4] COPY ./src .                                                                                                                                                                     0.0s
 => [nginx] exporting to image                                                                                                                                                                          0.0s
 => => exporting layers                                                                                                                                                                                 0.0s
 => => writing image sha256:773b0a600a557d640dc34aed477a49387dc892e6929902b63e747c9dd00b01c2                                                                                                            0.0s
 => => naming to docker.io/library/astro-web-indexer-nginx                                                                                                                                              0.0s
 => CACHED [php  2/10] RUN apt-get update && apt-get install -y     default-mysql-client     libzip-dev     zip     unzip  && rm -rf /var/lib/apt/lists/*                                               0.0s
 => CACHED [php  3/10] RUN docker-php-ext-install pdo_mysql zip                                                                                                                                         0.0s
 => CACHED [php  4/10] RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer                                                                         0.0s
 => CACHED [php  5/10] WORKDIR /var/www/html                                                                                                                                                            0.0s
 => CACHED [php  6/10] COPY src/ .                                                                                                                                                                      0.0s
 => CACHED [php  7/10] RUN echo v1.0.2-1-g4f37537-dirty > VERSION                                                                                                                                       0.0s
 => CACHED [php  8/10] RUN composer install --no-interaction --no-progress --no-dev --optimize-autoloader                                                                                               0.0s
 => CACHED [php  9/10] COPY docker/php/docker-entrypoint.sh /usr/local/bin/                                                                                                                             0.0s
 => CACHED [php 10/10] RUN chmod +x /usr/local/bin/docker-entrypoint.sh                                                                                                                                 0.0s
 => [php] exporting to image                                                                                                                                                                            0.0s
 => => exporting layers                                                                                                                                                                                 0.0s
 => => writing image sha256:6b5653fa02a99ad9353d6c3034d8003e9d8c178d04482300b88500f78d100ff2                                                                                                            0.0s
 => => naming to docker.io/library/astro-web-indexer-php                                                                                                                                                0.0s
 => [mariadb] resolving provenance for metadata file                                                                                                                                                    0.0s
 => [nginx] resolving provenance for metadata file                                                                                                                                                      0.0s
 => [php] resolving provenance for metadata file                                                                                                                                                        0.0s
 => [python 3/9] WORKDIR /opt/scripts                                                                                                                                                                   0.0s
 => [python 4/9] RUN python -m venv /opt/venv                                                                                                                                                           5.3s
 => [python 5/9] COPY docker/python/requirements.txt .                                                                                                                                                  0.0s
 => [python 6/9] RUN /opt/venv/bin/pip install --no-cache-dir -r requirements.txt                                                                                                                      14.9s
 => [python 7/9] RUN /opt/venv/bin/pip install git+https://github.com/sergio-dr/xisf.git                                                                                                               48.0s
 => [python 8/9] COPY docker/python/reindex.py .                                                                                                                                                        0.0s
 => [python 9/9] COPY docker/python/watch_fs.py .                                                                                                                                                       0.0s
 => [python] exporting to image                                                                                                                                                                         1.1s
 => => exporting layers                                                                                                                                                                                 1.1s
 => => writing image sha256:481d8e7fb5381a8fb695549deabce17c705db4b52c69c0bc4c85bab20029f122                                                                                                            0.0s
 => => naming to docker.io/library/astro-web-indexer-python                                                                                                                                             0.0s
 => [python] resolving provenance for metadata file                                                                                                                                                     0.0s
[+] Building 4/4
 ✔ astro-web-indexer-mariadb  Built                                                                                                                                                                     0.0s
 ✔ astro-web-indexer-nginx    Built                                                                                                                                                                     0.0s
 ✔ astro-web-indexer-php      Built                                                                                                                                                                     0.0s
 ✔ astro-web-indexer-python   Built                                                                                                                                                                     0.0s
[+] Running 5/5
 ✔ Network astro-web-indexer_default  Created                                                                                                                                                           0.0s
 ✔ Container mariadb-awi              Healthy                                                                                                                                                          10.8s
 ✔ Container php-awi                  Started                                                                                                                                                          10.9s
 ✔ Container python-awi               Started                                                                                                                                                          10.9s
 ✔ Container nginx-awi                Started                                                                                                                                                          11.1s
Build complete. Astro Web Indexer is running.
```